### PR TITLE
Fixes for SSP 1.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "license": "LGPL-2.1",
     "type": "simplesamlphp-module",
     "require": {
-        "simplesamlphp/composer-module-installer": "~1.0",
-        "simplesamlphp/simplesamlphp": ">=1.15"
+        "simplesamlphp/composer-module-installer": "~1.1.8",
+        "simplesamlphp/simplesamlphp": ">=1.19"
     },
     "support": {
         "issues": "https://github.com/simplesamlphp/simplesamlphp-module-stepupsfo/issues",

--- a/lib/Auth/Process/SFO.php
+++ b/lib/Auth/Process/SFO.php
@@ -109,7 +109,7 @@ class sspmod_stepupsfo_Auth_Process_SFO extends SimpleSAML_Auth_ProcessingFilter
         $ar->setNameId($nameid);
         $ar->setRelayState($relay);
 
-        SimpleSAML\Logger::debug('Sending SAML 2 SFO AuthnRequest for ' . $nameid->value .  ' to ' .
+        SimpleSAML\Logger::debug('Sending SAML 2 SFO AuthnRequest for ' . $nameid->getValue() .  ' to ' .
             var_export($idpMetadata->getString('entityid'), true). ' with id ' . $ar->getId());
 
         $dst = $idpMetadata->getEndpointPrioritizedByBinding('SingleSignOnService',

--- a/lib/Auth/Process/SFO.php
+++ b/lib/Auth/Process/SFO.php
@@ -62,7 +62,8 @@ class sspmod_stepupsfo_Auth_Process_SFO extends SimpleSAML_Auth_ProcessingFilter
             throw new Exception("Subjectid " . var_export($subjectid,true) . " does not start with urn:collab:person:");
         }
 
-        $nameid = \SAML2\XML\saml\NameID::fromArray(['Value' => $subjectid]);
+        $nameid = new \SAML2\XML\saml\NameID();
+        $nameid->setValue($subjectid);
 
         // Start the authentication request
         $this->startSFO($this->idpMetadata, $nameid, $samlstateid);


### PR DESCRIPTION
SSP 1.19 dropped support from array-style NameIDs. Use setters instead